### PR TITLE
Remove u and p query parameters (username and password) as influxdb f…

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -3,19 +3,11 @@
 }
 
 {$PROTOCOL}://{$INFLUX_DOMAIN} {
-    # Block any requests in which a different username or password are specified
-    @block_username query u=*
-    @block_password query p=*
-
-    handle @block_username {
-        respond 403
-    }
-
-    handle @block_password {
-        respond 403
-    }
-
     handle /query {
+        # Remove credentials in query parameters if they exist. Influxdb favors those over header credentials
+        uri query -u
+        uri query -p
+
         reverse_proxy influxdb:8086 {
             header_up Authorization "Basic cHVibGljOnB1YmxpYw=="  # public:public credentials, overwrite any previous Authorization header.
         }


### PR DESCRIPTION
…avors those of credentials authentication. Instead of blocking any requests containing those parameters. Some libraries have hardcoded credentials.